### PR TITLE
Update jsDelivr links

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,13 +74,13 @@ Load the Zebra_Dialog jQuery plugin:
 <script src="path/to/zebra_dialog.min.js"></script>
 ```
 
-Alternatively, you can load Zebra_Dialog from [JSDelivr CDN](https://www.jsdelivr.com/) like this:
+Alternatively, you can load Zebra_Dialog from [JSDelivr CDN](https://www.jsdelivr.com/package/npm/zebra_dialog) like this:
 ```html
 <!-- for the most recent version -->
-<script src="https://cdn.jsdelivr.net/gh/stefangabos/Zebra_Dialog/dist/zebra_dialog.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/zebra_dialog/dist/zebra_dialog.min.js"></script>
 
 <!-- for a specific version -->
-<script src="https://cdn.jsdelivr.net/gh/stefangabos/Zebra_Dialog@1.3.0/dist/zebra_dialog.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/zebra_dialog@1.4.0/dist/zebra_dialog.min.js"></script>
 
 <!-- replacing "min" with "src" will serve you the non-compressed version -->
 ```
@@ -95,10 +95,10 @@ Load the style sheet file from a local source
 
 ```html
 <!-- for the most recent version of the "flat" theme -->
-<link rel="stylesheet" href=="https://cdn.jsdelivr.net/gh/stefangabos/Zebra_Dialog/dist/css/flat/zebra_dialog.min.css">
+<link rel="stylesheet" href=="https://cdn.jsdelivr.net/npm/zebra_dialog@latest/dist/css/flat/zebra_dialog.min.css">
 
 <!-- for the most recent version of the "default" theme -->
-<link rel="stylesheet" href=="https://cdn.jsdelivr.net/gh/stefangabos/Zebra_Dialog/dist/css/flat/zebra_dialog.min.css">
+<link rel="stylesheet" href=="https://cdn.jsdelivr.net/npm/zebra_dialog@latest/dist/css/default/zebra_dialog.min.css">
 
 <!-- replacing "min" with "src" will serve you the non-compressed version -->
 ```


### PR DESCRIPTION
Hi this is Lukas from jsDelivr.

While our new back-end supports serving files from both npm and GitHub, we recommend always using only one of these methods for every package, with npm being the preferred one (using only npm means you can get detailed package usage statistics and npm packages are also searchable on our website).

I updated the links to use our npm endpoint. I also fixed one of the css links, because they we're pointing to the same file.

You can find links for all files at https://www.jsdelivr.com/package/npm/zebra_dialog.

Feel free to ping me if you have any questions regarding this change.