### PR TITLE
Place focus on first button only if not already on the dialog

### DIFF
--- a/src/zebra_dialog.src.js
+++ b/src/zebra_dialog.src.js
@@ -455,7 +455,10 @@
                 }
 
                 // move the focus to the first of the dialog box's buttons
-                plugin.dialog.find('a[class^=ZebraDialog_Button]:first').focus();
+                if (0 ===  $((null === document.activeElement) ? document : document.activeElement).parents('.ZebraDialog').length) {
+                    // move the focus to the first of the dialog box's buttons
+                    plugin.dialog.find('a[class^=ZebraDialog_Button]:first').focus();
+                }
 
                 // if the browser is Internet Explorer 6, call the "_emulate_fixed_position" method
                 // (if we do not apply a short delay, it sometimes does not work as expected)


### PR DESCRIPTION
As described in Focus lost on Android device #14